### PR TITLE
Session/5

### DIFF
--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -12,17 +12,17 @@ class WeatherService {
   /// If successful, the value is stored in [Success],
   /// if unsuccessful, the error message is stored in [Failure].
 
-  Result<WeatherCondition?, String> fetchWeather() {
+  Result<WeatherCondition, String> fetchWeather() {
     try {
       final condition = _client.fetchThrowsWeather('Aichi');
       final weatherCondition = WeatherCondition.values.byNameOrNull(condition);
       if (weatherCondition == null) {
-        return const Failure<WeatherCondition?, String>('unknown');
+        return const Failure<WeatherCondition, String>('unknown');
       }
-      return Success<WeatherCondition?, String>(weatherCondition);
+      return Success<WeatherCondition, String>(weatherCondition);
     } on YumemiWeatherError catch (_) {
       // 投げられるエラーは`YumemiWeatherError.unknown`だけ
-      return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
+      return const Failure<WeatherCondition, String>('予期せぬエラーが発生しました。');
     }
   }
 }

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -12,7 +12,7 @@ class WeatherService {
   /// If successful, the value is stored in "Success",
   /// if unsuccessful, the error message is stored in "Failure".
 
-  Result<WeatherCondition?, String> fetchWeather(YumemiWeather client) {
+  Result<WeatherCondition?, String> fetchWeather() {
     try {
       final condition = _client.fetchThrowsWeather('Aichi');
       final weatherCondition = WeatherCondition.values.byNameOrNull(condition);

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -9,8 +9,8 @@ class WeatherService {
   final YumemiWeather _client;
 
   /// Get weather information
-  /// If successful, the value is stored in "Success",
-  /// if unsuccessful, the error message is stored in "Failure".
+  /// If successful, the value is stored in [Success],
+  /// if unsuccessful, the error message is stored in [Failure].
 
   Result<WeatherCondition?, String> fetchWeather() {
     try {

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -21,7 +21,7 @@ class WeatherService {
       }
       return Success<WeatherCondition?, String>(weatherCondition);
     } on YumemiWeatherError catch (_) {
-      // 投げられる例外は`YumemiWeatherError.unknown`だけ
+      // 投げられるエラーは`YumemiWeatherError.unknown`だけ
       return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
     }
   }

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -17,7 +17,7 @@ class WeatherService {
       final condition = _client.fetchThrowsWeather('Aichi');
       final weatherCondition = WeatherCondition.values.byNameOrNull(condition);
       if (weatherCondition == null) {
-        return const Failure<WeatherCondition, String>('unknown');
+        return const Failure<WeatherCondition?, String>('unknown');
       }
       return Success<WeatherCondition?, String>(weatherCondition);
     } on YumemiWeatherError catch (_) {

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -21,6 +21,7 @@ class WeatherService {
       }
       return Success<WeatherCondition?, String>(weatherCondition);
     } on YumemiWeatherError catch (_) {
+      // 投げられる例外は`YumemiWeatherError.unknown`だけ
       return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
     }
   }

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -20,13 +20,8 @@ class WeatherService {
         return const Failure<WeatherCondition, String>('unknown');
       }
       return Success<WeatherCondition?, String>(weatherCondition);
-    } on YumemiWeatherError catch (e) {
-      switch (e) {
-        case YumemiWeatherError.invalidParameter:
-          return const Failure<WeatherCondition?, String>('パラメータが間違っています。');
-        case YumemiWeatherError.unknown:
-          return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
-      }
+    } on YumemiWeatherError catch (_) {
+      return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
     }
   }
 }

--- a/lib/service/weather_service.dart
+++ b/lib/service/weather_service.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_training/model/weather_condition.dart';
+import 'package:flutter_training/utils/api/result.dart';
+import 'package:flutter_training/utils/extention/enum.dart';
+import 'package:yumemi_weather/yumemi_weather.dart';
+
+class WeatherService {
+  WeatherService(this._client);
+
+  final YumemiWeather _client;
+
+  /// Get weather information
+  /// If successful, the value is stored in "Success",
+  /// if unsuccessful, the error message is stored in "Failure".
+
+  Result<WeatherCondition?, String> fetchWeather(YumemiWeather client) {
+    try {
+      final condition = _client.fetchThrowsWeather('Aichi');
+      final weatherCondition = WeatherCondition.values.byNameOrNull(condition);
+      if (weatherCondition == null) {
+        return const Failure<WeatherCondition, String>('unknown');
+      }
+      return Success<WeatherCondition?, String>(weatherCondition);
+    } on YumemiWeatherError catch (e) {
+      switch (e) {
+        case YumemiWeatherError.invalidParameter:
+          return const Failure<WeatherCondition?, String>('パラメータが間違っています。');
+        case YumemiWeatherError.unknown:
+          return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
+      }
+    }
+  }
+}

--- a/lib/utils/api/result.dart
+++ b/lib/utils/api/result.dart
@@ -1,0 +1,15 @@
+sealed class Result<S, E extends String> {
+  const Result();
+}
+
+final class Success<S, E extends String> extends Result<S, E> {
+  const Success(this.value);
+
+  final S value;
+}
+
+final class Failure<S, E extends String> extends Result<S, E> {
+  const Failure(this.exception);
+
+  final E exception;
+}

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_training/model/weather_condition.dart';
 import 'package:flutter_training/service/weather_service.dart';
 import 'package:flutter_training/utils/api/result.dart';
-import 'package:flutter_training/utils/extention/enum.dart';
 import 'package:flutter_training/view/weather_view/component/weather_forecast.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -24,6 +24,7 @@ class _WeatherPageState extends State<WeatherPage> {
         break;
       case Failure(exception: final error):
         showDialog<void>(
+          barrierDismissible: false,
           context: context,
           builder: (_) => _ErrorDialog(error),
         );

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -18,16 +18,14 @@ class _WeatherPageState extends State<WeatherPage> {
 
   void _onReloaded() {
     //fetchWeatherの結果がSuccessかFailureかで処理を分ける
-    switch (service.fetchWeather()) {
-      case Success(value: final value):
-        setState(() => weatherCondition = value);
-      case Failure(exception: final error):
-        showDialog<void>(
+    return switch (service.fetchWeather()) {
+      Success(value: final value) => setState(() => weatherCondition = value),
+      Failure(exception: final error) => showDialog<void>(
           barrierDismissible: false,
           context: context,
           builder: (_) => _ErrorDialog(error),
-        );
-    }
+        ),
+    };
   }
 
   @override

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -21,14 +21,12 @@ class _WeatherPageState extends State<WeatherPage> {
     switch (service.fetchWeather()) {
       case Success(value: final value):
         setState(() => weatherCondition = value);
-        break;
       case Failure(exception: final error):
         showDialog<void>(
           barrierDismissible: false,
           context: context,
           builder: (_) => _ErrorDialog(error),
         );
-        break;
     }
   }
 

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -17,7 +17,7 @@ class _WeatherPageState extends State<WeatherPage> {
 
   //天気を取得してweatherConditionに代入する
   void fetchWeather() {
-    final condition = _client.fetchSimpleWeather();
+    final condition = _client.fetchThrowsWeather('Aichi');
     setState(() {
       weatherCondition = WeatherCondition.values.byNameOrNull(condition);
     });

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/model/weather_condition.dart';
+import 'package:flutter_training/service/weather_service.dart';
 import 'package:flutter_training/utils/api/result.dart';
 import 'package:flutter_training/utils/extention/enum.dart';
 import 'package:flutter_training/view/weather_view/component/weather_forecast.dart';
@@ -14,7 +15,21 @@ class WeatherPage extends StatefulWidget {
 
 class _WeatherPageState extends State<WeatherPage> {
   WeatherCondition? weatherCondition;
-  final _client = YumemiWeather();
+  final service = WeatherService(YumemiWeather());
+
+  void _onReloaded() {
+    switch (service.fetchWeather()) {
+      case Success(value: final value):
+        setState(() => weatherCondition = value);
+        break;
+      case Failure(exception: final error):
+        showDialog<void>(
+          context: context,
+          builder: (_) => _ErrorDialog(error),
+        );
+        break;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,19 +55,7 @@ class _WeatherPageState extends State<WeatherPage> {
                         ),
                         Expanded(
                           child: TextButton(
-                            onPressed: () {
-                              switch (fetchWeather()) {
-                                case Success(value: final value):
-                                  setState(() => weatherCondition = value);
-                                  break;
-                                case Failure(exception: final error):
-                                  showDialog<void>(
-                                    context: context,
-                                    builder: (_) => _ErrorDialog(error),
-                                  );
-                                  break;
-                              }
-                            },
+                            onPressed: _onReloaded,
                             child: const Text('Reload'),
                           ),
                         ),

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -16,25 +16,6 @@ class _WeatherPageState extends State<WeatherPage> {
   WeatherCondition? weatherCondition;
   final _client = YumemiWeather();
 
-  //天気を取得してweatherConditionに代入する
-  Result<WeatherCondition?, String> fetchWeather() {
-    try {
-      final condition = _client.fetchThrowsWeather('Aichi');
-      weatherCondition = WeatherCondition.values.byNameOrNull(condition);
-      if (weatherCondition == null) {
-        return const Failure<WeatherCondition, String>('unknown');
-      }
-      return Success<WeatherCondition?, String>(weatherCondition);
-    } on YumemiWeatherError catch (e) {
-      switch (e) {
-        case YumemiWeatherError.invalidParameter:
-          return const Failure<WeatherCondition?, String>('パラメータが間違っています。');
-        case YumemiWeatherError.unknown:
-          return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/model/weather_condition.dart';
+import 'package:flutter_training/utils/api/result.dart';
 import 'package:flutter_training/utils/extention/enum.dart';
 import 'package:flutter_training/view/weather_view/component/weather_forecast.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
@@ -16,11 +17,24 @@ class _WeatherPageState extends State<WeatherPage> {
   final _client = YumemiWeather();
 
   //天気を取得してweatherConditionに代入する
-  void fetchWeather() {
-    final condition = _client.fetchThrowsWeather('Aichi');
-    setState(() {
+  Result<WeatherCondition?, String> fetchWeather() {
+    try {
+      final condition = _client.fetchThrowsWeather('Aichi');
       weatherCondition = WeatherCondition.values.byNameOrNull(condition);
-    });
+      if (weatherCondition == null) {
+        return const Failure<WeatherCondition, String>('unknown');
+      }
+      return Success<WeatherCondition?, String>(
+        WeatherCondition.values.byNameOrNull(condition),
+      );
+    } on YumemiWeatherError catch (e) {
+      switch (e) {
+        case YumemiWeatherError.invalidParameter:
+          return const Failure<WeatherCondition?, String>('パラメータが間違っています。');
+        case YumemiWeatherError.unknown:
+          return const Failure<WeatherCondition?, String>('予期せぬエラーが発生しました。');
+      }
+    }
   }
 
   @override

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -61,7 +61,19 @@ class _WeatherPageState extends State<WeatherPage> {
                         ),
                         Expanded(
                           child: TextButton(
-                            onPressed: fetchWeather,
+                            onPressed: () {
+                              switch (fetchWeather()) {
+                                case Success(value: final value):
+                                  setState(() => weatherCondition = value);
+                                  break;
+                                case Failure(exception: final error):
+                                  showDialog<void>(
+                                    context: context,
+                                    builder: (_) => _ErrorDialog(error),
+                                  );
+                                  break;
+                              }
+                            },
                             child: const Text('Reload'),
                           ),
                         ),
@@ -74,6 +86,26 @@ class _WeatherPageState extends State<WeatherPage> {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _ErrorDialog extends StatelessWidget {
+  const _ErrorDialog(this.errorMessage);
+
+  final String errorMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('エラー'),
+      content: Text(errorMessage),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('OK'),
+        )
+      ],
     );
   }
 }

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -17,6 +17,7 @@ class _WeatherPageState extends State<WeatherPage> {
   final service = WeatherService(YumemiWeather());
 
   void _onReloaded() {
+    //fetchWeatherの結果がSuccessかFailureかで処理を分ける
     switch (service.fetchWeather()) {
       case Success(value: final value):
         setState(() => weatherCondition = value);

--- a/lib/view/weather_view/weather_page.dart
+++ b/lib/view/weather_view/weather_page.dart
@@ -24,9 +24,7 @@ class _WeatherPageState extends State<WeatherPage> {
       if (weatherCondition == null) {
         return const Failure<WeatherCondition, String>('unknown');
       }
-      return Success<WeatherCondition?, String>(
-        WeatherCondition.values.byNameOrNull(condition),
-      );
+      return Success<WeatherCondition?, String>(weatherCondition);
     } on YumemiWeatherError catch (e) {
       switch (e) {
         case YumemiWeatherError.invalidParameter:


### PR DESCRIPTION
## 課題

#6 対応

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の OK ボタンをタップすると、ダイアログを閉じる
  * `OK`をタップしないと閉じれないように、`barrierDismissible`を`false`に設定

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
| ![expected](https://raw.githubusercontent.com/yumemi-inc/flutter-training-template/main/docs/sessions/images/error/demo.gif)     | <video src="https://github.com/mqkotoo/flutter_training/assets/87256037/d2d7d530-2855-4ecc-9bc4-bd757ab6136f"/>|
